### PR TITLE
Add option Env variables for composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - printf '[defaults]\nroles_path=../' >ansible.cfg
   - ansible --version
   - ansible-galaxy install carlosbuenosvinos.ansistrano-deploy --force
-  - ln -s `pwd` ../cbrunnkvist.ansistrano-symfony-deploy
+  - ln -s `pwd` ../eheuje.ansistrano-symfony-deploy
 
 script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ symfony_run_composer: true
 symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
+symfony_composer_environment: [] # Symfony default composer.json comes with command Incenteev\\ParameterHandler\\ScriptHandler::buildParameters which can use environment variables to build the parameters.yml file (see https://github.com/Incenteev/ParameterHandler#using-environment-variables-to-set-the-parameters)
 
 symfony_run_assets_install: true
 symfony_assets_options: '--no-interaction'

--- a/config/after_symlink_shared.yml
+++ b/config/after_symlink_shared.yml
@@ -1,17 +1,17 @@
-- include: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/composer.yml"
+- include: "../../eheuje.ansistrano-symfony-deploy/config/steps/composer.yml"
   when: symfony_run_composer
 
-- include: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/assets.yml"
+- include: "../../eheuje.ansistrano-symfony-deploy/config/steps/assets.yml"
   when: symfony_run_assets_install
 
-- include: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/assetic.yml"
+- include: "../../eheuje.ansistrano-symfony-deploy/config/steps/assetic.yml"
   when: symfony_run_assetic_dump
 
-- include: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/cache.yml"
+- include: "../../eheuje.ansistrano-symfony-deploy/config/steps/cache.yml"
   when: symfony_run_cache_clear_and_warmup
 
-- include: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/doctrine.yml"
+- include: "../../eheuje.ansistrano-symfony-deploy/config/steps/doctrine.yml"
   when: symfony_run_doctrine_migrations
 
-- include: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/mongodb.yml"
+- include: "../../eheuje.ansistrano-symfony-deploy/config/steps/mongodb.yml"
   when: symfony_run_mongodb_schema_update

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -16,4 +16,5 @@
   shell: chdir={{ansistrano_release_path.stdout}}
     export SYMFONY_ENV={{symfony_env}} && {{symfony_php_path}} {{symfony_composer_path}} install {{symfony_composer_options}}
   register: composer_install_result
+  environment: {{symfony_composer_environment}}
   changed_when: composer_install_result.stderr | search('- \w+ing ')

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -16,5 +16,5 @@
   shell: chdir={{ansistrano_release_path.stdout}}
     export SYMFONY_ENV={{symfony_env}} && {{symfony_php_path}} {{symfony_composer_path}} install {{symfony_composer_options}}
   register: composer_install_result
-  environment: {{symfony_composer_environment}}
+  environment: "{{symfony_composer_environment}}"
   changed_when: composer_install_result.stderr | search('- \w+ing ')

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ symfony_run_composer: true
 symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
+symfony_composer_environment: []
 
 symfony_run_assets_install: true
 symfony_assets_options: '--no-interaction'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   gather_facts: false
   roles:
-    - cbrunnkvist.ansistrano-symfony-deploy
+    - eheuje.ansistrano-symfony-deploy
 
   vars:
     ansistrano_deploy_to: /tmp/test_app

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-ansistrano_after_update_code_tasks_file: "../../cbrunnkvist.ansistrano-symfony-deploy/config/after_update_code.yml"
-ansistrano_after_symlink_shared_tasks_file: "../../cbrunnkvist.ansistrano-symfony-deploy/config/after_symlink_shared.yml"
+ansistrano_after_update_code_tasks_file: "../../eheuje.ansistrano-symfony-deploy/config/after_update_code.yml"
+ansistrano_after_symlink_shared_tasks_file: "../../eheuje.ansistrano-symfony-deploy/config/after_symlink_shared.yml"


### PR DESCRIPTION
Symfony default composer.json comes with the command Incenteev\\ParameterHandler\\ScriptHandler::buildParameters which can use environment variables to build the parameters.yml file (see https://github.com/Incenteev/ParameterHandler#using-environment-variables-to-set-the-parameters).

Here's a part of the compoer.json

```json
    "extra": {
        "symfony-app-dir": "app",
        "symfony-web-dir": "web",
        "symfony-assets-install": "relative",
        "incenteev-parameters": {
            "file": "app/config/parameters.yml",
            "keep-outdated": true,
            "env-map": {
                "database_host": "DATABASE_HOST",
                "database_port": "DATABASE_PORT",
                "database_name": "DATABASE_NAME",
                "database_user": "DATABASE_USER",
                "database_password": "DATABASE_PASSWORD"
            }
        }
    }
```
And the ansible playbook exemple

```YAML
---
- hosts: all
  gather_facts: false
  vars:
    ansistrano_deploy_from: ../my-project-checkout
    ansistrano_deploy_to: /home/app-user/my-project-deploy/
    ansistrano_before_symlink_tasks_file: "{{playbook_dir}}/config/app_specific_setup.yml"
    symfony_composer_environment:
      DATABASE_HOST: localhost
      DATABASE_PORT: 3306
      DATABASE_NAME: my_database
      DATABASE_USER: foo
      DATABASE_PASSWORD: bar
  roles:
    - cbrunnkvist.ansistrano-symfony-deploy
```

