### PR TITLE
Add option to execute Composer self-update as privileged user

### DIFF
--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -5,8 +5,21 @@
 
 - name: Run composer self-update
   shell: "{{symfony_composer_path}} selfupdate --no-interaction"
-  when: composer_file.stat.exists and symfony_composer_self_update
+  when:
+    - composer_file.stat.exists
+    - symfony_composer_self_update
+    - not symfony_composer_self_update_privileged
   register: composer_self_update_result
+  changed_when: composer_self_update_result.stderr | search('Updating')
+
+- name: Run composer self-update as privileged user
+  shell: "{{symfony_composer_path}} selfupdate --no-interaction"
+  when:
+    - composer_file.stat.exists
+    - symfony_composer_self_update
+    - symfony_composer_self_update_privileged
+  register: composer_self_update_result
+  become: yes
   changed_when: composer_self_update_result.stderr | search('Updating')
 
 - name: Install composer

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ symfony_run_composer: true
 symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
+symfony_composer_self_update_privileged: false # Allows to run composer self-update as privileged user
 
 symfony_run_assets_install: true
 symfony_assets_options: '--no-interaction'


### PR DESCRIPTION
Since composer can be installed in directory owned by privileged users
(e.g.: /usr/local/bin) it should be able to be written by the privileged
owner user during the self-update.