### PR TITLE
Fix compatibility warning with boolean vars

### DIFF
--- a/config/after_symlink_shared.yml
+++ b/config/after_symlink_shared.yml
@@ -1,41 +1,41 @@
 - include_tasks: "{{ ansistrano_symfony_before_composer_tasks_file | default('steps/empty.yml') }}"
 
 - import_tasks: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/composer.yml"
-  when: symfony_run_composer
+  when: symfony_run_composer|bool
 
 - include_tasks: "{{ ansistrano_symfony_after_composer_tasks_file | default('steps/empty.yml') }}"
 
 - include_tasks: "{{ ansistrano_symfony_before_assets_tasks_file | default('steps/empty.yml') }}"
 
 - import_tasks: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/assets.yml"
-  when: symfony_run_assets_install
+  when: symfony_run_assets_install|bool
 
 - include_tasks: "{{ ansistrano_symfony_after_assets_tasks_file | default('steps/empty.yml') }}"
 
 - include_tasks: "{{ ansistrano_symfony_before_assetic_tasks_file | default('steps/empty.yml') }}"
 
 - import_tasks: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/assetic.yml"
-  when: symfony_run_assetic_dump
+  when: symfony_run_assetic_dump|bool
 
 - include_tasks: "{{ ansistrano_symfony_after_assetic_tasks_file | default('steps/empty.yml') }}"
 
 - include_tasks: "{{ ansistrano_symfony_before_cache_tasks_file | default('steps/empty.yml') }}"
 
 - import_tasks: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/cache.yml"
-  when: symfony_run_cache_clear_and_warmup
+  when: symfony_run_cache_clear_and_warmup|bool
 
 - include_tasks: "{{ ansistrano_symfony_after_cache_tasks_file | default('steps/empty.yml') }}"
 
 - include_tasks: "{{ ansistrano_symfony_before_doctrine_tasks_file | default('steps/empty.yml') }}"
 
 - import_tasks: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/doctrine.yml"
-  when: symfony_run_doctrine_migrations
+  when: symfony_run_doctrine_migrations|bool
 
 - include_tasks: "{{ ansistrano_symfony_after_doctrine_tasks_file | default('steps/empty.yml') }}"
 
 - include_tasks: "{{ ansistrano_symfony_before_mongodb_tasks_file | default('steps/empty.yml') }}"
 
 - import_tasks: "../../cbrunnkvist.ansistrano-symfony-deploy/config/steps/mongodb.yml"
-  when: symfony_run_mongodb_schema_update
+  when: symfony_run_mongodb_schema_update|bool
 
 - include_tasks: "{{ ansistrano_symfony_after_mongodb_tasks_file | default('steps/empty.yml') }}"

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -5,7 +5,7 @@
 
 - name: Run composer self-update
   shell: "{{symfony_composer_path}} selfupdate --no-interaction"
-  when: composer_file.stat.exists and symfony_composer_self_update
+  when: composer_file.stat.exists and symfony_composer_self_update|bool
   register: composer_self_update_result
   changed_when: composer_self_update_result.stderr is search('Updating')
 


### PR DESCRIPTION
The warning:
```
[DEPRECATION WARNING]: evaluating symfony_run_assets_install as a bare 
variable, this behaviour will go away and you might need to add |bool to the 
expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle..
This feature will be removed in version 2.12. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
```

Tested with:   
```
> docker run --rm -it  webdevops/ansible:debian-9 ansible --version
ansible 2.8.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]
```