### PR TITLE
Default install stable version of composer, by adding symfony_compose…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ symfony_run_composer: true
 symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
+symfony_composer_version: 1.10.1 # Install specific composer version. If this variable is not set the last stable version is installed
 
 symfony_run_assets_install: true
 symfony_assets_options: '--no-interaction'

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -11,7 +11,7 @@
 
 - name: Install stable composer
   get_url: url=https://getcomposer.org/composer-stable.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
-  when: symfony_composer_version is undefined
+  when: symfony_composer_version is not defined
 
 - name: Install composer {{symfony_composer_version}}
   get_url: url=https://getcomposer.org/download/{{symfony_composer_version}}/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no

--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -9,8 +9,13 @@
   register: composer_self_update_result
   changed_when: composer_self_update_result.stderr is search('Updating')
 
-- name: Install composer
+- name: Install stable composer
   get_url: url=https://getcomposer.org/composer-stable.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
+  when: symfony_composer_version is undefined
+
+- name: Install composer {{symfony_composer_version}}
+  get_url: url=https://getcomposer.org/download/{{symfony_composer_version}}/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
+  when: symfony_composer_version is defined
 
 - name: Run composer install
   shell: chdir={{ansistrano_release_path.stdout}}


### PR DESCRIPTION
The purpose of this PR is to be able to specify a version of composer to install (in case you do not want to migrate immediately to composer 2.0 for example).

By default the role behavior is not affected, it continues to install the latest stable version unless you add the symfony_composer_version variable.


It's the first time that I do a PR on an ansible role so I probably forget a lot of configuration / documentation so I'm open to all sugesstion.