### PR TITLE
Allow ignore composer upgrade

### DIFF
--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -5,7 +5,7 @@
 
 - name: Run composer self-update
   shell: "{{symfony_composer_path}} selfupdate --no-interaction"
-  when: composer_file.stat.exists and symfony_composer_self_update|bool
+  when: composer_file.stat.exists and symfony_composer_self_update | bool
   register: composer_self_update_result
   changed_when: composer_self_update_result.stderr is search('Updating')
 
@@ -15,7 +15,10 @@
 
 - name: Install composer {{symfony_composer_version}}
   get_url: url=https://getcomposer.org/download/{{symfony_composer_version}}/composer.phar dest={{symfony_composer_path}} mode=0755 validate_certs=no force=no
-  when: symfony_composer_version is defined
+  when:
+    - symfony_composer_version is defined
+    - not symfony_composer_self_update | bool
+    - not composer_file.stat.exists or symfony_composer_upgrade | bool
 
 - name: Run composer install
   shell: chdir={{ansistrano_release_path.stdout}}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ symfony_run_composer: true
 symfony_composer_path: "{{ ansistrano_deploy_to }}/composer.phar"
 symfony_composer_options: '--no-dev --optimize-autoloader --no-interaction'
 symfony_composer_self_update: true # Always attempt a composer self-update
+symfony_composer_upgrade: true # Try to upgrade composer to 'symfony_composer_version' if already installed
 
 symfony_run_assets_install: true
 symfony_assets_options: '--no-interaction'


### PR DESCRIPTION
Sometimes getcomposer.org is unavailable but role wants to upgrade composer whenever it is already installed or not.
This PR adds `symfony_composer_upgrade` (default true) option which:

* stats for composer.phar
* when true: always tries upgrade to `symfony_composer_version`
* when false: upgrades to `symfony_composer_version` only if composer.phar not exists