### PR TITLE
Use symfony_php_path to run composer selfupdate

### DIFF
--- a/config/steps/composer.yml
+++ b/config/steps/composer.yml
@@ -4,7 +4,7 @@
   register: composer_file
 
 - name: Run composer self-update
-  shell: "{{symfony_composer_path}} selfupdate --no-interaction"
+  shell: "{{symfony_php_path}} {{symfony_composer_path}} selfupdate --no-interaction"
   when: composer_file.stat.exists and symfony_composer_self_update|bool
   register: composer_self_update_result
   changed_when: composer_self_update_result.stderr is search('Updating')


### PR DESCRIPTION
Currently, if you use an OS with only custom PHP executable (e.g., /usr/bin/php81), the command `composer selfupdate` fails. This PR uses the variable `symfony_php_path` to run that command.